### PR TITLE
Add strict CSP for Tauri WebView

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Security
+- Added a strict Content Security Policy to the Tauri WebView (`default-src 'self'`, no `'unsafe-eval'`, no remote sources). Defense-in-depth against XSS in untrusted data the app renders (clipboard contents, filenames). Thanks to @mdunphy for the suggestion (#10).
+
+### Changed
+- Bumped `@tauri-apps/api` to `~2.10.0` (#11).
+
 ## [0.2.3] - 2026-05-08
 
 ### Added

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -22,7 +22,7 @@
       }
     ],
     "security": {
-      "csp": null
+      "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self'; connect-src 'self' ipc: http://ipc.localhost; frame-src 'none'; object-src 'none'; base-uri 'self'; form-action 'none'"
     }
   },
   "plugins": {


### PR DESCRIPTION
## Summary

Adds a strict Content Security Policy to the Tauri WebView as defense-in-depth for the untrusted data the app renders (clipboard contents, filenames). Currently safely escaped by React, but the CSP guarantees that future regressions can't escalate into XSS.

- `script-src 'self'` — no inline scripts, no `eval`.
- `style-src 'self' 'unsafe-inline'` — `'unsafe-inline'` retained because React inline `style={{…}}` props are pervasive in [src/App.tsx](src/App.tsx) and [src/components/ShortcutRecorder.tsx](src/components/ShortcutRecorder.tsx). Refactoring to className-only would be a separate, larger change.
- `connect-src 'self' ipc: http://ipc.localhost` — Tauri IPC keeps working; nothing else can phone home.
- `font-src 'self'` — Inter is already vendored locally (#7).
- `frame-src`, `object-src`, `form-action` all `'none'`.

Closes #8

## Test plan

- [x] `npm run build` — Vite bundle clean.
- [x] `npx tauri info` — config parses, CSP echoed back verbatim.
- [x] `cargo check` in [src-tauri/](src-tauri/) — clean.
- [x] `npm run tauri dev` — manual smoke test: clipboard sync, settings panel, shortcut recorder, GNOME-extension link. No CSP violation reports in DevTools console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)