### PR TITLE
Bump @tauri-apps/api to ~2.10.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.2.2",
       "dependencies": {
         "@fontsource/inter": "^5.2.8",
-        "@tauri-apps/api": "^2.9.1",
+        "@tauri-apps/api": "~2.10.0",
         "@tauri-apps/plugin-autostart": "^2.5.1",
         "@tauri-apps/plugin-notification": "^2.3.3",
         "@tauri-apps/plugin-opener": "^2.5.2",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@fontsource/inter": "^5.2.8",
-    "@tauri-apps/api": "^2.9.1",
+    "@tauri-apps/api": "~2.10.0",
     "@tauri-apps/plugin-autostart": "^2.5.1",
     "@tauri-apps/plugin-notification": "^2.3.3",
     "@tauri-apps/plugin-opener": "^2.5.2",


### PR DESCRIPTION
## Summary

- Pins `@tauri-apps/api` to `~2.10.0` (was `^2.9.1`).

## Test plan

- [x] `npm install` resolves without warnings.
- [x] `npm run build` clean.
- [ ] Smoke-test the packaged app — IPC calls (`invoke`, `listen`, `getCurrentWindow`) still functional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)